### PR TITLE
所持金表示を定数から変数に修正

### DIFF
--- a/TaimaiwoHatake/RightPanel.pde
+++ b/TaimaiwoHatake/RightPanel.pde
@@ -48,14 +48,14 @@ class RightPanel {
     fill(255);
     textSize(30);
     text("所持金", width * 0.3 + 80, 60);
-    text(ENEMY_POINT + "pt", width * 0.3 + 80, 100);
+    text(ai.wallet + "pt", width * 0.3 + 80, 100);
 
     fill(240);
     rect(width * 0.3 + 20, height - 120, 120, 100);
 
     fill(21, 96, 130);
     text("所持金", width * 0.3 + 80, height - 80);
-    text(PLAYER_POINT + "pt", width * 0.3 + 80, height - 40);
+    text(player.wallet + "pt", width * 0.3 + 80, height - 40);
   }
 
   // 出荷準備エリア


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要/目的
所持金を画面に正しく表示するための修正
## 変更/更新内容の詳細
RightPanelの[ENEMY_POINT][PLAYER_POINT]をそれぞれ[ai.wallet][player.wallet]に変更
## 動作確認の箇所や方法(任意)
実行して米購入したら画面下の所持金が変わります
## 注意事項/懸念事項(任意)

## レビュアーへの依頼事項(任意)

<!-- I want to review in Japanese. -->