### PR TITLE
fluctuationPopUpの完成 / 市場の初期在庫をキープする配列の修正

### DIFF
--- a/TaimaiwoHatake/Popup.pde
+++ b/TaimaiwoHatake/Popup.pde
@@ -307,7 +307,18 @@ class Popup {
     strokeWeight(2);
     rect((width * 0.3) + 110, 160, (width * 0.7) - 190, height - 320);
     
-    textAlign(LEFT, CENTER);
+    for (int i=0; i<riceBrandsInfo.length; i++) {
+      fill(255);
+      textSize(40);
+      textAlign(LEFT, CENTER);
+      stroke(riceBrandsInfo[riceBrandRanking[i]].brandColor);
+      rect((width * 0.3) + 220, 300 + (i*60), 30, 45); // デモ用のカード
+      fill(riceBrandsInfo[riceBrandRanking[i]].brandColor);
+      text(riceBrandsInfo[riceBrandRanking[i]].name, (width * 0.3) + 270, 320 + (i*60));
+      fill(0);
+      text(marketStockKeep[riceBrandRanking[i]] + "→" + market.marketStock[riceBrandRanking[i]], (width * 0.3) + 600, 320 + (i*60));
+    }
+    
     fill(0);
     textSize(40);
     text("集計結果", (width * 0.3) + 370, 210);

--- a/TaimaiwoHatake/TaimaiwoHatake.pde
+++ b/TaimaiwoHatake/TaimaiwoHatake.pde
@@ -176,7 +176,10 @@ void initGame() {
   gameLogic = new GameLogic();
   player = new Player(PLAYER_POINT);
   ai = new AI(ENEMY_POINT);
-
+  
+  // その時の供給在庫を更新
+  marketStockKeep = market.marketStock.clone();
+  
   // UI系
   ui = new UI(gameState);
   leftPanel = new LeftPanel(ui);


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要/目的
fluctuationPopUpの完成、市場の初期在庫をキープする配列の修正
## 変更/更新内容の詳細
fluctuationPopupに米の名前、ブランドカラー、初期在庫、出荷後在庫の表示を追加 / 市場の初期在庫をキープする配列を、正しく値を取得するよう修正
## 動作確認の箇所や方法(任意)

## 注意事項/懸念事項(任意)

## レビュアーへの依頼事項(任意)

<!-- I want to review in Japanese. -->